### PR TITLE
2.6.10 - circular ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mu-ts/endpoints",
-  "version": "2.6.9",
+  "version": "2.6.10",
   "description": "Simple REST endpoint and action routing.",
   "main": "./lib/index",
   "types": "./lib/index",

--- a/src/EndpointRoutes.ts
+++ b/src/EndpointRoutes.ts
@@ -79,7 +79,7 @@ export class EndpointRoutes {
    * @param instanceArgs arguments to supply into the constructor of the instance.
    */
   private static getInstance(_constructor: any, _instanceArgs?: any | any[]): any {
-    this.logger.debug({ data: { _constructor, _instanceArgs } }, 'getInstance()', '--> ');
+    this.logger.debug({ data: { _constructor, _instanceArgs: (_instanceArgs) ? Object.keys(_instanceArgs) : undefined } }, 'getInstance()', '--> ');
     let instance = this._instances.get(_constructor['name']);
     if (!instance) {
       this.logger.debug({ data: { namne: _constructor['name'] } }, 'getInstance()', ' -- creating instance ');

--- a/src/decorators/endpoints.ts
+++ b/src/decorators/endpoints.ts
@@ -10,7 +10,7 @@ export function endpoints(pathPrefix?: string, instanceArgs?: any[]) {
     const parent: string = target.constructor.name;
     const logConfig: LoggerConfig = { name: `${parent}.endpoints`, adornments: { '@mu-ts': 'endpoints' } };
     const logger: Logger = LoggerService.named(logConfig);
-    logger.debug({ pathPrefix, instanceArgs }, 'endpoints()', 'initializing');
+    logger.debug({ pathPrefix, instanceArgs: (instanceArgs) ? Object.keys(instanceArgs) : undefined }, 'endpoints()', 'initializing');
     EndpointRoutes.init(target, pathPrefix || '', instanceArgs);
   };
 }


### PR DESCRIPTION
When logging out the arguments for an endpoint, when they are complex objects logger was going to deep and causing circular reference issues.